### PR TITLE
Fix config retrieval

### DIFF
--- a/src/PrometheusServiceProvider.php
+++ b/src/PrometheusServiceProvider.php
@@ -49,7 +49,7 @@ class PrometheusServiceProvider extends ServiceProvider
         $this->app->bind(Adapter::class, function ($app) {
             $factory = $app['prometheus.storage_adapter_factory']; /** @var StorageAdapterFactory $factory */
             $driver = config('prometheus.storage_adapter');
-            $configs = config('storage_adapters');
+            $configs = config('prometheus.storage_adapters');
             $config = array_get($configs, $driver, []);
             return $factory->make($driver, $config);
         });


### PR DESCRIPTION
At PrometheusServiceProvider, the varaible $configs  was trying to access an unexisting key storage_adapters, since this variable only exists in the prometheus config.