### PR TITLE
Route name to configs

### DIFF
--- a/config/prometheus.php
+++ b/config/prometheus.php
@@ -41,6 +41,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Metrics Route Name
+    |--------------------------------------------------------------------------
+    |
+    | Route Parh name aliase.
+    |
+    | This is only applicable if metrics_route_enabled is set to true.
+    |
+    */
+
+    'metrics_route_name' => env('PROMETHEUS_METRICS_ROUTE_NAME', 'metrics'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Metrics Route Middleware
     |--------------------------------------------------------------------------
     |

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,9 +1,15 @@
 <?php
 
+/** @var \Illuminate\Routing\Route $route */
 $route = Route::get(
     config('prometheus.metrics_route_path'),
     \Superbalist\LaravelPrometheusExporter\MetricsController::class . '@getMetrics'
-)->name('metrics'); /** @var \Illuminate\Routing\Route $route */
+);
+
+if ($name = config('prometheus.metrics_route_name')) {
+    $route->name($name);
+}
+
 $middleware = config('prometheus.metrics_route_middleware');
 
 if ($middleware) {


### PR DESCRIPTION
Hi, i faced a little problem using your package with Lumen. Lumen uses `Laravel\Lumen\Routing\Router` class instead of `Illuminate\Routing\Route`, which don't implement `name()` method. I moved route name to configuration file, so it can be set to null/false and `name()` method won't be called.