### PR TITLE
Enable package discovery for laravel 5.5+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,14 @@
   "extra": {
     "branch-alias": {
       "dev-master": "1.0-dev"
+    },
+    "laravel": {
+      "providers": [
+        "Superbalist\\LaravelPrometheusExporter\\PrometheusServiceProvider"
+      ],
+      "aliases": {
+        "Prometheus": "Superbalist\\LaravelPrometheusExporter\\PrometheusFacade"
+      }
     }
   },
   "require-dev": {


### PR DESCRIPTION
It would be really helpful to allow automated package discovery for this if using Laravel >=5.5. I've updated the composer.json file to allow this.

I hope you would accept it because it reduces the amount of manual steps someone has to do to install this excellent package.

Would you also like me to update the readme to note this change?