### PR TITLE
Don't test against PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - nightly
+  - 7.2
 
 before_install:
   - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 before_install:
   - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.0",
+    "phpunit/phpunit": "^5.5",
     "mockery/mockery": "^0.9.5"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.5",
+    "phpunit/phpunit": "^8.0",
     "mockery/mockery": "^0.9.5"
   }
 }


### PR DESCRIPTION
Turn off testing against the Travis CI nightly PHP build as this has been upgraded to PHP 8.0 which is not compatible with any version of PHPUnit: https://phpunit.de/supported-versions.html