### PR TITLE
Replace abandoned Jimdo/prometheus_client_php dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=5.6.0",
     "illuminate/support": "^5.3 || ^6.0 || ^7.0",
     "illuminate/routing": "^5.3 || ^6.0 || ^7.0",
-    "jimdo/prometheus_client_php": "^0.9.0"
+    "endclothing/prometheus_client_php": "^1.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
From the issue #11:

https://github.com/Jimdo/prometheus_client_php is archived and no longer maintained. 
They didn't add the `abandoned` value in `composer.json`, so there's no link to it from there, but they linked to this repository in the readme: https://github.com/endclothing/prometheus_client_php .

This changes the dependency accordingly.

This will bump the required minimum PHP Version to 7.1.

Closes #11 