### PR TITLE
Adds support for PHP >= 7.2 and switch to endclothing/prometheus_client_php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 before_install:
   - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
   ],
   "require": {
     "php": ">=7.2.0",
-    "illuminate/support": "^5.3 || ^6.0 || ^7.0",
-    "illuminate/routing": "^5.3 || ^6.0 || ^7.0",
+    "illuminate/support": "^5.3 || ^6.0 || ^7.0 || ^8.0",
+    "illuminate/routing": "^5.3 || ^6.0 || ^7.0 || ^8.0",
     "endclothing/prometheus_client_php": "^1.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "superbalist/laravel-prometheus-exporter",
+  "name": "futurematt/laravel-prometheus-exporter",
   "description": "A prometheus exporter for Laravel",
   "license": "MIT",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,6 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8",
-    "mockery/mockery": "^1.4"
+    "mockery/mockery": "^1.3"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.5",
-    "mockery/mockery": "^0.9.5"
+    "phpunit/phpunit": "^8",
+    "mockery/mockery": "^1.4"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
     }
   ],
   "require": {
-    "php": ">=5.6.0",
+    "php": ">=7.2.0",
     "illuminate/support": "^5.3 || ^6.0 || ^7.0",
     "illuminate/routing": "^5.3 || ^6.0 || ^7.0",
-    "jimdo/prometheus_client_php": "^0.9.0"
+    "endclothing/prometheus_client_php": "^1.0"
   },
   "autoload": {
     "psr-4": {
@@ -34,7 +34,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.5",
-    "mockery/mockery": "^0.9.5"
+    "phpunit/phpunit": "^8",
+    "mockery/mockery": "^1.3"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
     }
   ],
   "require": {
-    "php": ">=5.6.0",
+    "php": ">=7.2.0",
     "illuminate/support": "^5.3 || ^6.0 || ^7.0",
     "illuminate/routing": "^5.3 || ^6.0 || ^7.0",
-    "jimdo/prometheus_client_php": "^0.9.0"
+    "endclothing/prometheus_client_php": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="true"
 >
     <testsuites>


### PR DESCRIPTION
This MR switches the required Prometheus Client package from jimdo/prometheus_client_php to endclothing/prometheus_client_php.

All support for versions of PHP prior to 7.2 are dropped in this MR.

Also the minimum required version of PHPUnit is now 8.0 and mockery is 1.3. This was done in order to support PHP 7.4. These aren't the latest versions of the testing packages as those drop support for versions on PHP < 7.3 so in order to maximize compatibility with 7.x versions of PHP I opted for slightly older versions.